### PR TITLE
Added functionality to track and output weekly spawn, harvest, and kill data

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -242,6 +242,19 @@ end
 
 
 """
+  INPUT: final_week = final week from simulate's "current_week" IE. the last
+    week of the simulation.
+  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+
+  Last update: June 2016
+"""
+function harvestData(hdf::DataFrame, path::ASCIIString)
+  file = string(path,"\\harvestSUMMARY.csv")
+  writetable(file, hdf)
+end
+
+
+"""
   INPUT: See: aliveData() & simReadme().
 
   Description: General function for FishEBM.jl to automatically generate summary
@@ -251,9 +264,10 @@ end
 
   Last update: June 2016
 """
-function simSummary(adultAssumpt::AdultAssumptions, agentAssumpt::AgentAssumptions, agentDB::Vector, bump::Vector, effort::Vector, finalWeek::Int64, initStock::Vector, carryingCap::Vector, popDataFrame::DataFrame, userInput::ASCIIString)
+function simSummary(adultAssumpt::AdultAssumptions, agentAssumpt::AgentAssumptions, agentDB::Vector, bump::Vector, effort::Vector, finalWeek::Int64, initStock::Vector, carryingCap::Vector, popDataFrame::DataFrame, harvestDataFrame::DataFrame, userInput::ASCIIString)
   simDir()
   path = runDir(dateDir(resultsDir(setProjPath())[1])[1])[2]
   aliveData(popDataFrame, path)
+  harvestData(harvestDataFrame, path)
   simReadme(adultAssumpt, agentAssumpt, bump, effort, initStock, carryingCap, path, userInput)
 end

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -229,8 +229,7 @@ end
 
 
 """
-  INPUT: final_week = final week from simulate's "current_week" IE. the last
-    week of the simulation.
+  INPUT: popDataFrame = DataFrame of weekly stage population.
   OUTPUT: simSUMMARY.csv: file containing weekly population levels.
 
   Last update: June 2016
@@ -242,9 +241,8 @@ end
 
 
 """
-  INPUT: final_week = final week from simulate's "current_week" IE. the last
-    week of the simulation.
-  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+  INPUT: hdf = DataFrame of weekly age-specific harvest levels and total harvest.
+  OUTPUT: harvestSUMMARY.csv: file containing weekly harvest levels.
 
   Last update: June 2016
 """
@@ -255,9 +253,8 @@ end
 
 
 """
-  INPUT: final_week = final week from simulate's "current_week" IE. the last
-    week of the simulation.
-  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+  INPUT: sdf = DataFrame of weekly age-specific spawn levels and total spawn size.
+  OUTPUT: spawnSUMMARY.csv: file containing weekly spawn levels.
 
   Last update: June 2016
 """
@@ -268,9 +265,8 @@ end
 
 
 """
-  INPUT: final_week = final week from simulate's "current_week" IE. the last
-    week of the simulation.
-  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+  INPUT: kdf = DataFrame of weekly killed data by natural and extra mortality.
+  OUTPUT: killedSUMMARY.csv: file containing weekly mortality levels.
 
   Last update: June 2016
 """

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -255,6 +255,19 @@ end
 
 
 """
+  INPUT: final_week = final week from simulate's "current_week" IE. the last
+    week of the simulation.
+  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+
+  Last update: June 2016
+"""
+function spawnData(sdf::DataFrame, path::ASCIIString)
+  file = string(path,"\\spawnSUMMARY.csv")
+  writetable(file, sdf)
+end
+
+
+"""
   INPUT: See: aliveData() & simReadme().
 
   Description: General function for FishEBM.jl to automatically generate summary
@@ -264,10 +277,12 @@ end
 
   Last update: June 2016
 """
-function simSummary(adultAssumpt::AdultAssumptions, agentAssumpt::AgentAssumptions, agentDB::Vector, bump::Vector, effort::Vector, finalWeek::Int64, initStock::Vector, carryingCap::Vector, popDataFrame::DataFrame, harvestDataFrame::DataFrame, userInput::ASCIIString)
+function simSummary(adultAssumpt::AdultAssumptions, agentAssumpt::AgentAssumptions, agentDB::Vector, bump::Vector, effort::Vector, finalWeek::Int64, initStock::Vector,
+  carryingCap::Vector, popDataFrame::DataFrame, harvestDataFrame::DataFrame, spawnDataFrame::DataFrame, userInput::ASCIIString)
   simDir()
   path = runDir(dateDir(resultsDir(setProjPath())[1])[1])[2]
   aliveData(popDataFrame, path)
   harvestData(harvestDataFrame, path)
+  spawnData(spawnDataFrame, path)
   simReadme(adultAssumpt, agentAssumpt, bump, effort, initStock, carryingCap, path, userInput)
 end

--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -268,6 +268,19 @@ end
 
 
 """
+  INPUT: final_week = final week from simulate's "current_week" IE. the last
+    week of the simulation.
+  OUTPUT: simSUMMARY.csv: file containing weekly population levels.
+
+  Last update: June 2016
+"""
+function killedData(kdf::DataFrame, path::ASCIIString)
+  file = string(path,"\\killedSUMMARY.csv")
+  writetable(file, kdf)
+end
+
+
+"""
   INPUT: See: aliveData() & simReadme().
 
   Description: General function for FishEBM.jl to automatically generate summary
@@ -278,11 +291,12 @@ end
   Last update: June 2016
 """
 function simSummary(adultAssumpt::AdultAssumptions, agentAssumpt::AgentAssumptions, agentDB::Vector, bump::Vector, effort::Vector, finalWeek::Int64, initStock::Vector,
-  carryingCap::Vector, popDataFrame::DataFrame, harvestDataFrame::DataFrame, spawnDataFrame::DataFrame, userInput::ASCIIString)
+  carryingCap::Vector, popDataFrame::DataFrame, harvestDataFrame::DataFrame, spawnDataFrame::DataFrame, killedDataFrame::DataFrame, userInput::ASCIIString)
   simDir()
   path = runDir(dateDir(resultsDir(setProjPath())[1])[1])[2]
   aliveData(popDataFrame, path)
   harvestData(harvestDataFrame, path)
   spawnData(spawnDataFrame, path)
+  killedData(killedDataFrame, path)
   simReadme(adultAssumpt, agentAssumpt, bump, effort, initStock, carryingCap, path, userInput)
 end

--- a/src/FishEBM.jl
+++ b/src/FishEBM.jl
@@ -43,6 +43,7 @@ module FishEBM
     simReadme,
     aliveData,
     harvestData,
+    spawnData,
     simSummary,
 
     # simulationResults.jl functions

--- a/src/FishEBM.jl
+++ b/src/FishEBM.jl
@@ -44,6 +44,7 @@ module FishEBM
     aliveData,
     harvestData,
     spawnData,
+    killedData,
     simSummary,
 
     # simulationResults.jl functions

--- a/src/FishEBM.jl
+++ b/src/FishEBM.jl
@@ -42,6 +42,7 @@ module FishEBM
     simDir,
     simReadme,
     aliveData,
+    harvestData,
     simSummary,
 
     # simulationResults.jl functions

--- a/src/agents.jl
+++ b/src/agents.jl
@@ -129,7 +129,7 @@ end
 
   Last Update: June 2016
 """
-function spawn!(agent_db::Vector, adult_a::AdultAssumptions, age_assumpt::AgentAssumptions, enviro_a::EnvironmentAssumptions, week::Int64, carryingcapacity::Float64)
+function spawn!(agent_db::Vector, adult_a::AdultAssumptions, age_assumpt::AgentAssumptions, enviro_a::EnvironmentAssumptions, week::Int64, carryingcapacity::Float64, sdf::DataFrame)
 
   adult_pop = getStagePopulation(4, week, agent_db, age_assumpt)
 
@@ -161,6 +161,7 @@ function spawn!(agent_db::Vector, adult_a::AdultAssumptions, age_assumpt::AgentA
     newClass += 1
   end
 
+  brood_size = fill(0, size(adult_a.broodsize))
 
   for i = 1:length(enviro_a.spawningHash)
     if isEmpty(agent_db[enviro_a.spawningHash[i]]) == false
@@ -173,12 +174,16 @@ function spawn!(agent_db::Vector, adult_a::AdultAssumptions, age_assumpt::AgentA
             brood = rand(Poisson(compensation_factor_a*adult_a.broodsize[age - 1]), rand(Binomial(ageSpecificPop, cdf(Binomial(length(adult_a.broodsize)+2, min(1, compensation_factor_b*adult_a.halfmature/(length(adult_a.broodsize)+2))), age)*0.5)))
             for k = 1:length(brood)
               agent_db[enviro_a.spawningHash[i]].alive[newClass] += brood[k]
+              brood_size[age - 1] += brood[k]
             end #for k=1:brood
           end #for j = 1:numSpawningAdults
         end #if ageSpecificPop
       end #for ages
     end #if isEmpty
   end #for i=1:length spawningHash
+
+  push!(sdf, (vcat(week, brood_size..., sum(brood_size))))
+
 end
 
 

--- a/src/agents.jl
+++ b/src/agents.jl
@@ -250,7 +250,7 @@ end
 
   Last Update: June 2016
 """
-function harvest!(effort::Float64, week::Int64, agent_db::Vector, enviro_a::EnvironmentAssumptions, adult_a::AdultAssumptions, a_a::AgentAssumptions)
+function harvest!(effort::Float64, week::Int64, agent_db::Vector, enviro_a::EnvironmentAssumptions, adult_a::AdultAssumptions, a_a::AgentAssumptions, hdf::DataFrame)
 
   harvest_size = fill(0, size(adult_a.catchability))
   ageSpecificPop = fill(0, size(adult_a.catchability))
@@ -266,6 +266,8 @@ function harvest!(effort::Float64, week::Int64, agent_db::Vector, enviro_a::Envi
   for i = 1:length(harvest_size)
     harvest_size[i] = rand(Poisson(ageSpecificPop[i]*adult_a.catchability[i]*effort))
   end
+
+  push!(hdf, (vcat(week, harvest_size..., sum(harvest_size)))) #Add each age specific harvest size to dataframe
 
   harvest_loc = sample(find(enviro_a.spawningHash), rand(1:10)) #generate random harvest locations
 

--- a/src/agents.jl
+++ b/src/agents.jl
@@ -339,8 +339,10 @@ end
 
   Last update: June 2016
 """
-function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumptions, current_week::Int64)
+function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumptions, current_week::Int64, kdf::DataFrame)
   classLength = length((agent_db[1]).weekNum)
+  totalNatural = 0
+  totalExtra = 0
 
   for i = 1:length(agent_db)
     #Check if class is empty. If not empty, continue with kill function. Otherwise skip to next agent
@@ -356,11 +358,13 @@ function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumpti
           #and natural mortality in the form of a probability
           killedNatural = rand(Binomial(agent_db[i].alive[j], a_a.naturalmortality[habitat, stage]))
           agent_db[i].killedNatural[stage] += killedNatural
+          totalNatural += killedNatural
           agent_db[i].alive[j] -= killedNatural
           if agent_db[i].alive[j] > 0
             if in(agent_db[i].locationID, e_a.risk) #Check if this particular locationID is in risk zone
               killedExtra = rand(Binomial(agent_db[i].alive[j], a_a.extramortality[stage]))
               agent_db[i].killedExtra[stage] += killedExtra
+              totalExtra += killedExtra
               agent_db[i].alive[j] -= killedExtra
             end #if risk
           end #if agent_db[i].alive (inner)
@@ -368,6 +372,10 @@ function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumpti
       end #for j=1:classLength
     end #if isEmpty
   end #for i=1:length(agent_db)
+
+  total = totalNatural + totalExtra
+
+  push!(kdf, (current_week, totalNatural, totalExtra, total))
 
   return agent_db
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -35,6 +35,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   popDataFrame = DataFrame(Week = 0, Stage1 = initStock[1], Stage2 = initStock[2], Stage3 = initStock[3],Stage4 = initStock[4], Total = sum(initStock))
   harvestDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
   spawnDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
+  killedDataFrame = DataFrame(Week = 0, Natural = 0, Extra = 0, Total = 0)
 
   spawn!(a_db, adult_a, age_a, e_a, 1, carrying_capacity[1], spawnDataFrame)
 
@@ -77,7 +78,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       end
 
       #Agents are killed and moved weekly
-      kill!(a_db, e_a, age_a, totalWeek)
+      kill!(a_db, e_a, age_a, totalWeek, killedDataFrame)
       move!(a_db, age_a, e_a, totalWeek)
 
       #update population information
@@ -101,7 +102,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       if totalPopulation == 0 || totalPopulation > limit
         removeEmptyClass!(a_db)
         description = "Simulation was stopped in year $y, week $w due to population failure (total population = $totalPopulation, population limit = $limit)."
-        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, description)
+        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, killedDataFrame, description)
         return a_db
       end
 
@@ -111,6 +112,6 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   end #end for year
 
   description = "Simulation was successfully completed."
-  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, description)
+  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, killedDataFrame, description)
   return a_db
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -63,6 +63,13 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
 
       totalWeek = ((y-1)*52)+w
 
+      ageSpecificPop = fill(0, 7)
+      for i = 1:length(a_db)
+        for age = 2:8
+          ageSpecificPop[age - 1] += getAgeSpecificPop(age, totalWeek, a_db[i].alive, a_db[i].weekNum, age_a)
+        end #for age
+      end #for i
+
       #harvest and spawn can be set to any week(s)
       if w > harvestMin
         #harvest can be set to any week(s)

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -34,8 +34,9 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
 
   popDataFrame = DataFrame(Week = 0, Stage1 = initStock[1], Stage2 = initStock[2], Stage3 = initStock[3],Stage4 = initStock[4], Total = sum(initStock))
   harvestDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
+  spawnDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
 
-  spawn!(a_db, adult_a, age_a, e_a, 1, carrying_capacity[1])
+  spawn!(a_db, adult_a, age_a, e_a, 1, carrying_capacity[1], spawnDataFrame)
 
   bumpvec = fill(0, years)
   bumpvec[1:length(bump)] = bump
@@ -70,7 +71,9 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       end
 
       if w > spawnMin
-        spawn!(a_db, adult_a, age_a, e_a, totalWeek, carrying_capacity[y])
+        spawn!(a_db, adult_a, age_a, e_a, totalWeek, carrying_capacity[y], spawnDataFrame)
+      else
+        push!(spawnDataFrame, (totalWeek, 0, 0, 0, 0, 0, 0, 0, 0))
       end
 
       #Agents are killed and moved weekly
@@ -98,7 +101,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       if totalPopulation == 0 || totalPopulation > limit
         removeEmptyClass!(a_db)
         description = "Simulation was stopped in year $y, week $w due to population failure (total population = $totalPopulation, population limit = $limit)."
-        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, description)
+        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, description)
         return a_db
       end
 
@@ -108,6 +111,6 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   end #end for year
 
   description = "Simulation was successfully completed."
-  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, description)
+  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, spawnDataFrame, description)
   return a_db
 end

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -33,6 +33,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   end
 
   popDataFrame = DataFrame(Week = 0, Stage1 = initStock[1], Stage2 = initStock[2], Stage3 = initStock[3],Stage4 = initStock[4], Total = sum(initStock))
+  harvestDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
 
   spawn!(a_db, adult_a, age_a, e_a, 1, carrying_capacity[1])
 
@@ -63,7 +64,9 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       #harvest and spawn can be set to any week(s)
       if w > harvestMin
         #harvest can be set to any week(s)
-        harvest!(harvest_effort[y], totalWeek, a_db, e_a, adult_a, age_a)
+        harvest!(harvest_effort[y], totalWeek, a_db, e_a, adult_a, age_a, harvestDataFrame)
+      else
+        push!(harvestDataFrame, (totalWeek, 0, 0, 0, 0, 0, 0, 0, 0))
       end
 
       if w > spawnMin
@@ -95,7 +98,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       if totalPopulation == 0 || totalPopulation > limit
         removeEmptyClass!(a_db)
         description = "Simulation was stopped in year $y, week $w due to population failure (total population = $totalPopulation, population limit = $limit)."
-        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, description)
+        simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, description)
         return a_db
       end
 
@@ -105,6 +108,6 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   end #end for year
 
   description = "Simulation was successfully completed."
-  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, description)
+  simSummary(adult_a, age_a, a_db, bump, effort, ((length(carrying_capacity))*52), initStock, carrying_capacity, popDataFrame, harvestDataFrame, description)
   return a_db
 end


### PR DESCRIPTION
- spawn and harvest data are output by age specific numbers and the sum of those (since spawn and harvest are adult events)
- kill data is output by natural and extra mortality and the sum of those
- Also added functionality in simulate.j to find total age-specific population and save it to a vector
