### PR TITLE
Added tracking for compensatory mortalities

### DIFF
--- a/src/FileIO.jl
+++ b/src/FileIO.jl
@@ -114,6 +114,16 @@ end
 function killedData(kdf::DataFrame, path::ASCIIString)
   file = string(path,"$(getDirChar())killedSUMMARY.csv")
   f = open(file, "w")
+
+  #Sum natural, extra, and Compensatory mortalities before outputting to .csv
+  for i = 1:size(kdf)[1]
+    totalKill = 0
+    for j = 2:4
+      totalKill += kdf[i,j]
+    end #for j
+    kdf[i,5] = totalKill
+  end #for i
+
   kdfOut = convert(Array, kdf)
   writedlm(f, names(kdf)', " ,")
   writedlm(f, kdfOut,  " ,")

--- a/src/mortality.jl
+++ b/src/mortality.jl
@@ -116,9 +116,12 @@ function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumpti
     end #if isEmpty
   end #for i=1:length(agent_db)
 
-  total = totalNatural + totalExtra
+  #total = totalNatural + totalExtra
 
-  push!(kdf, (current_week, totalNatural, totalExtra, total))
+  #push!(kdf, (current_week, totalNatural, totalExtra, total))
+
+  kdf[size(kdf)[1], 2] = totalNatural
+  kdf[size(kdf)[1], 3] = totalExtra
 
   return agent_db
 end
@@ -133,7 +136,9 @@ end
   Last update: June 2016
 """
 function killAgeSpecific!(agent_db::Vector, adult_a::AdultAssumptions,
-  age_specific_pop::Vector, year_specific_cc::Float64, current_week::Int64)
+  age_specific_pop::Vector, year_specific_cc::Float64, current_week::Int64, kdf::DataFrame)
+
+  totalKilled = 0
 
   stockSize = fill(0, size(adult_a.naturalmortality))
   ageVector = fill(0, length(agent_db[1].weekNum))
@@ -171,10 +176,13 @@ function killAgeSpecific!(agent_db::Vector, adult_a::AdultAssumptions,
         killedAdult = rand(Binomial(agent_db[j].alive[k], adult_a.naturalmortality[ageVector[k]-1]))
         agent_db[j].alive[k] -= killedAdult
 
-        #add code here for story the compensatory adult mortalities
+        totalKilled += 0
 
         k+=1
       end # while adult cohort
     end # if empty
   end # for agent_db
+
+  kdf[size(kdf)[1], 4] = totalKilled
+
 end

--- a/src/mortality.jl
+++ b/src/mortality.jl
@@ -116,10 +116,6 @@ function kill!(agent_db::Vector, e_a::EnvironmentAssumptions, a_a::AgentAssumpti
     end #if isEmpty
   end #for i=1:length(agent_db)
 
-  #total = totalNatural + totalExtra
-
-  #push!(kdf, (current_week, totalNatural, totalExtra, total))
-
   kdf[size(kdf)[1], 2] = totalNatural
   kdf[size(kdf)[1], 3] = totalExtra
 

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -41,7 +41,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
   ageDataFrame = DataFrame(Year = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
   harvestDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
   spawnDataFrame = DataFrame(Week = 0, Age2 = 0, Age3 = 0, Age4 = 0, Age5 = 0, Age6 = 0, Age7 = 0, Age8Plus = 0, Total = 0)
-  killedDataFrame = DataFrame(Week = 0, Natural = 0, Extra = 0, Total = 0)
+  killedDataFrame = DataFrame(Week = 0, Natural = 0, Extra = 0, Compensatory = 0, Total = 0)
 
   spawn!(a_db, adult_a, age_a, e_a, 1, carrying_capacity[1], spawnDataFrame)
 
@@ -92,7 +92,8 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       end
 
       #Agents are killed and moved weekly
-      killAgeSpecific!(a_db, adult_a, ageSpecificPop, carrying_capacity[y], totalWeek)
+      push!(killedDataFrame, (totalWeek, 0, 0, 0, 0))
+      killAgeSpecific!(a_db, adult_a, ageSpecificPop, carrying_capacity[y], totalWeek, killedDataFrame)
       kill!(a_db, e_a, age_a, totalWeek, killedDataFrame)
       move!(a_db, age_a, e_a, totalWeek)
 

--- a/src/simulate.jl
+++ b/src/simulate.jl
@@ -92,7 +92,7 @@ function simulate(carrying_capacity::Vector, effort::Vector, bump::Vector,
       end
 
       #Agents are killed and moved weekly
-      killAgeSpecific(a_db, adult_a, ageSpecificPop, carrying_capacity[y], totalWeek)
+      killAgeSpecific!(a_db, adult_a, ageSpecificPop, carrying_capacity[y], totalWeek)
       kill!(a_db, e_a, age_a, totalWeek, killedDataFrame)
       move!(a_db, age_a, e_a, totalWeek)
 


### PR DESCRIPTION
Since the age specific mortalities and natural mortalities don't take place in the same function, what I ended up doing was pushing a new row onto the killed data frame (to correspond to the new week since killing is weekly) before entering any of the killing functions, leaving each of the values in the new data frame row at 0, and then the kill functions update the corresponding data value in the data frame. In the FileIO, before the killed summary is output as a .csv file, the natural, extra, and comp mortalities are summed for each row of the data frame.
